### PR TITLE
Make title on category routes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ It provides the necessary controller extensions for Weblog to browse by category
 ## Features
 
 - Tag your blog posts with categories.
+- Unique URLs to filter by category.
 
 
 ## Documentation
 
 - [Installation](docs/en/Installation.md)
+- [Configuration](docs/en/Configuration.md)
 
 
 ## Requirements

--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -1,0 +1,13 @@
+# Configuration
+
+## Page title override in category view
+
+When navigating to a specific category, the blog page title is wrapped with
+information about that category. If the default formatting of this wrapper
+isn't suitable for your site, you can override it with configuration, using
+the provided `[page]` and `[category]` variables:
+
+```yml
+Axllent\Weblog\Extensions\BlogCategoriesControllerExt:
+  title_template: "[page]: [category]"
+```

--- a/src/Extensions/BlogCategoriesControllerExt.php
+++ b/src/Extensions/BlogCategoriesControllerExt.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Axllent\Weblog\Extensions;
 
 use SilverStripe\ORM\DataExtension;
@@ -22,6 +23,13 @@ class BlogCategoriesControllerExt extends DataExtension
     private static $url_handlers = [
         'category//$Category!' => 'displayCategory',
     ];
+
+    /**
+     * Template for overriding the page title with category information
+     *
+     * @var string
+     */
+    private static $title_template = 'Viewing category "[category]" | [page]';
 
     /**
      * Display category
@@ -49,8 +57,11 @@ class BlogCategoriesControllerExt extends DataExtension
 
         $orig_title = $this->owner->dataRecord->Title;
 
-        $this->owner->dataRecord->Title = 'Viewing category "' .
-        $category->Title . '" | ' . $orig_title;
+        $this->owner->dataRecord->Title = str_replace(
+            ['[category]', '[page]'],
+            [$category->Title, $orig_title],
+            $this->owner->config()->title_template
+        );
 
         $this->owner->blogPosts = $posts;
 


### PR DESCRIPTION
In order to include context about the current category, the `Title` field is directly overwritten on category routes, making it impossible to retrieve the original value.

Adding this configuration allows developers to optionally adjust the formatting of the overwritten value, or to simply reset it to only contain the title.